### PR TITLE
chore: Added virtual environment directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info
 
+# virtual environments
+.venv
 


### PR DESCRIPTION
Purely out of convenience: this adds the `.venv` directory to be ignored by git.
