### PR TITLE
Fixing double issue with tests

### DIFF
--- a/doc/source/operator_api.rst
+++ b/doc/source/operator_api.rst
@@ -16,9 +16,11 @@ adjoint operators, and experimental kernels.
    introduced without a full deprecation cycle while the interface and internal
    abstractions are still settling.
 
-   In particular, extent placeholders such as
-   :class:`gratopy.utilities.ExtentPlaceholder` are not yet implemented in the
-   operator API and currently raise :class:`NotImplementedError`.
+   Extent placeholders such as
+   :class:`gratopy.utilities.ExtentPlaceholder` are supported experimentally
+   for Radon operators when exactly one of the image or detector extents is a
+   placeholder. Passing placeholders for both extents at once remains
+   unsupported and raises :class:`NotImplementedError`.
 
 Current scope
 -------------
@@ -126,6 +128,42 @@ operator:
 This explicit style is particularly useful when experimenting with geometry in
 Python code, because image domain, angles, and detector settings become
 first-class objects that can be reused and modified independently.
+
+Extent placeholders
+-------------------
+
+For Radon operators, one physical extent can be inferred from the other by
+using :class:`gratopy.utilities.ExtentPlaceholder`. This is useful when one
+wants either the smallest detector covering a fixed image domain, or the
+largest image domain covered by a fixed detector.
+
+For example, the detector extent can be inferred from a fixed image extent:
+
+.. code-block:: python
+
+    from gratopy.utilities import Detectors, ExtentPlaceholder, ImageDomain
+
+    R = gratopy.operator.Radon(
+        image_domain=ImageDomain(size=128, extent=2.0),
+        angles=180,
+        detectors=Detectors(number=200, extent=ExtentPlaceholder.FULL),
+    )
+
+Conversely, the image extent can be inferred from a fixed detector extent:
+
+.. code-block:: python
+
+    R = gratopy.operator.Radon(
+        image_domain=ImageDomain(size=128, extent=ExtentPlaceholder.FULL),
+        angles=180,
+        detectors=Detectors(number=200, extent=2.0),
+    )
+
+Only one side may use an extent placeholder at a time. Passing placeholders for
+both the image and detector extents is unsupported and raises
+:class:`NotImplementedError`. If the requested placeholder semantics are
+geometrically impossible for the supplied centers and fixed extent, construction
+raises :class:`ValueError`.
 
 Operator algebra
 ----------------
@@ -242,8 +280,8 @@ Limitations and status
 The operator API is still evolving. In particular:
 
 - the focus is currently on :class:`gratopy.operator.projection.Radon`,
-- extent placeholders are not yet implemented and currently raise
-  :class:`NotImplementedError`,
+- extent placeholders are currently supported experimentally for Radon
+  operators when exactly one of the image or detector extents is a placeholder,
 - higher-level solver interfaces are still centered around the legacy API.
 
 For the full and mature feature set of gratopy, the legacy API documented in

--- a/gratopy/operator/projection.py
+++ b/gratopy/operator/projection.py
@@ -43,7 +43,16 @@ from typing import Any
 from gratopy.gratopy import radon_struct
 from gratopy.operator.base import Operator
 from gratopy.operator.opencl import OpenCLKernelSpec, _OpenCLOperator
-from gratopy.utilities import Angles, Detectors, ExtentPlaceholder, ImageDomain
+from gratopy.utilities import (
+    Angles,
+    Detectors,
+    ExtentPlaceholder,
+    ImageDomain,
+    full_detector_given_image_halfcircle,
+    full_image_given_detector_halfcircle,
+    valid_detector_given_image_halfcircle,
+    valid_image_given_detector_halfcircle,
+)
 
 
 class Radon(_OpenCLOperator):
@@ -143,7 +152,7 @@ class Radon(_OpenCLOperator):
             image_domain = ImageDomain(size=image_domain, extent=2.0)
 
         if not isinstance(angles, Angles):
-            angles = Angles.uniform(number=angles)
+            angles = Angles.uniform(number=angles,half_circle=True)
 
         if not isinstance(detectors, Detectors):
             if detectors is None:
@@ -208,15 +217,89 @@ class Radon(_OpenCLOperator):
         return operator_copy
 
     def substitute_placeholder(self) -> None:
-        """Reject extent placeholders until full support is implemented."""
-        if isinstance(self.image_domain.extent, ExtentPlaceholder) or isinstance(
+        """Resolve extent placeholders to concrete numeric values."""
+        if isinstance(self.image_domain.extent, ExtentPlaceholder) and isinstance(
             self.detectors.extent, ExtentPlaceholder
         ):
             raise NotImplementedError(
-                "Extent placeholders are not yet implemented in the experimental "
-                "operator API. Please pass explicit numeric extents for both the "
-                "image domain and the detector."
+                "Both the ImageDomain and Detectors use an ExtentPlaceholder. "
+                "Please set at least one of the two extents to a specific "
+                "value; the remaining placeholder will be resolved "
+                "automatically."
             )
+
+        if isinstance(self.image_domain.extent, ExtentPlaceholder):
+            Mx, My = self.image_domain.center
+            Md = self.detectors.center
+            Nx, Ny = self.image_domain.size
+            c = Nx / Ny
+            Dd = float(self.detectors.extent)
+            M = (Md, Mx, My)
+
+            if self.image_domain.extent == ExtentPlaceholder.FULL:
+                result = full_image_given_detector_halfcircle(M, Dd, c)
+            else:
+                result = valid_image_given_detector_halfcircle(M, Dd, c)
+
+            if result is None:
+                if self.image_domain.extent == ExtentPlaceholder.FULL:
+                    meaning = (
+                        "FULL means the largest image extent such that every "
+                        "ray through the image also hits the detector"
+                    )
+                else:
+                    meaning = (
+                        "VALID means the smallest image extent such that "
+                        "every ray hitting the detector also passes through "
+                        "the image"
+                    )
+                raise ValueError(
+                    f"Cannot resolve ExtentPlaceholder.{self.image_domain.extent.name} "
+                    f"for the image domain ({meaning}): no such image extent "
+                    f"exists with the given detector width Dd={Dd}, detector "
+                    f"center Md={Md}, and image center ({Mx}, {My}). "
+                    f"Consider increasing the detector width or adjusting the "
+                    f"center offsets."
+                )
+            Dx, Dy = result
+            self.image_domain.extent = max(Dx, Dy)
+
+        if isinstance(self.detectors.extent, ExtentPlaceholder):
+            Mx, My = self.image_domain.center
+            Md = self.detectors.center
+            Nx, Ny = self.image_domain.size
+            extent = float(self.image_domain.extent)
+            Dx = extent * Nx / max(Nx, Ny)
+            Dy = extent * Ny / max(Nx, Ny)
+            M = (Md, Mx, My)
+            D = (Dx, Dy)
+
+            if self.detectors.extent == ExtentPlaceholder.FULL:
+                result = full_detector_given_image_halfcircle(M, D)
+            else:
+                result = valid_detector_given_image_halfcircle(M, D)
+
+            if result is None:
+                if self.detectors.extent == ExtentPlaceholder.FULL:
+                    meaning = (
+                        "FULL means the smallest detector width such that "
+                        "every ray through the image also hits the detector"
+                    )
+                else:
+                    meaning = (
+                        "VALID means the largest detector width such that "
+                        "every ray hitting the detector also passes through "
+                        "the image"
+                    )
+                raise ValueError(
+                    f"Cannot resolve ExtentPlaceholder.{self.detectors.extent.name} "
+                    f"for the detector ({meaning}): no such detector width "
+                    f"exists with image dimensions ({Dx}, {Dy}), detector "
+                    f"center Md={Md}, and image center ({Mx}, {My}). "
+                    f"Consider increasing the image extent or adjusting the "
+                    f"center offsets."
+                )
+            self.detectors.extent = result
 
     def _ensure_host_struct(self, queue: cl.CommandQueue) -> None:
         if self._host_struct is not None:

--- a/gratopy/operator/projection.py
+++ b/gratopy/operator/projection.py
@@ -119,9 +119,13 @@ class Radon(_OpenCLOperator):
     - ``(Ns, Na)`` to ``(Nx, Ny)``,
     - ``(Ns, Na, Nz)`` to ``(Nx, Ny, Nz)``.
 
-    Extent placeholders in the experimental operator API are not yet
-    implemented. Passing :class:`gratopy.utilities.ExtentPlaceholder` values to
-    this class currently raises :class:`NotImplementedError`.
+    Extent placeholders are supported experimentally for Radon geometry when
+    exactly one extent is fixed numerically and the other is given as
+    :class:`gratopy.utilities.ExtentPlaceholder`. The operator can resolve an
+    image extent from a fixed detector extent, or a detector extent from a
+    fixed image extent. Passing placeholders for both extents at once remains
+    unsupported and raises :class:`NotImplementedError`; geometries for which
+    no valid placeholder resolution exists raise :class:`ValueError`.
 
     **Examples**
 

--- a/gratopy/utilities.py
+++ b/gratopy/utilities.py
@@ -310,3 +310,200 @@ class ImageDomain:
         self.size = size
         self.extent = extent
         self.center = center
+
+
+# ---------------------------------------------------------------------------
+# Halfcircle geometry formulas (phi in [0, pi])
+# ---------------------------------------------------------------------------
+
+
+def _solve_quadratic(a: float, b: float, d: float) -> tuple[float, float]:
+    """Solve ax^2 + bx + d = 0 and return (x1, x2) with x1 <= x2."""
+    discriminant = b**2 - 4 * a * d
+    sqrt_disc = np.sqrt(discriminant)
+    x1 = (-b - sqrt_disc) / (2 * a)
+    x2 = (-b + sqrt_disc) / (2 * a)
+    return (x1, x2)
+
+
+def full_detector_given_image_halfcircle(
+    M: tuple[float, float, float],
+    D: tuple[float, float],
+) -> float:
+    """Smallest detector width so every ray through the image hits the detector.
+
+    Half-circle variant (phi in [0, pi]).  See PDF Section 3.1, Eq. (5).
+
+    Parameters
+    ----------
+    M : (Md, Mx, My)
+        Detector center offset and image center coordinates.
+    D : (Dx, Dy)
+        Physical image dimensions.
+
+    Returns
+    -------
+    float
+        Required detector width Dd.
+    """
+    (Md, Mx, My) = M
+    (Dx, Dy) = D
+    # Coordinate rotation: the Max/Min formulas (1)-(2) were derived for
+    # f(phi) = a cos(phi) + b sin(phi), while the sinogram convention is
+    # s(phi) = x sin(phi) - y cos(phi).
+    (Mx, My) = (-My, Mx)
+    (Dx, Dy) = (Dy, Dx)
+
+    if My >= -Dy / 2:
+        MAX = np.sqrt((abs(Mx) + Dx / 2) ** 2 + (My + Dy / 2) ** 2)
+    else:
+        MAX = abs(Mx) + Dx / 2
+
+    if My <= Dy / 2:
+        MIN = -np.sqrt((abs(Mx) + Dx / 2) ** 2 + (My - Dy / 2) ** 2)
+    else:
+        MIN = -abs(Mx) - Dx / 2
+
+    Dd = 2 * max(Md - MIN, MAX - Md)
+    return Dd
+
+
+def full_image_given_detector_halfcircle(
+    M: tuple[float, float, float],
+    Dd: float,
+    c: float = 1.0,
+) -> tuple[float, float] | None:
+    """Largest image so every ray through it hits the detector.
+
+    Half-circle variant (phi in [0, pi]).  See PDF Section 3.2, Eqs. (6)-(12).
+
+    Parameters
+    ----------
+    M : (Md, Mx, My)
+        Detector center offset and image center coordinates.
+    Dd : float
+        Detector width.
+    c : float
+        Aspect ratio Dx / Dy.
+
+    Returns
+    -------
+    tuple[float, float] or None
+        Image dimensions (Dx, Dy), or None if no valid geometry exists.
+    """
+    (Md, Mx, My) = M
+
+    a1 = (1 + c**2) / (4 * c**2)
+    b1 = abs(My) / c + Mx
+    d1 = -(Md + Dd / 2) ** 2 + Mx**2 + My**2
+    (x1, x2) = _solve_quadratic(a1, b1, d1)
+
+    a2 = (1 + c**2) / (4 * c**2)
+    b2 = abs(My) / c - Mx
+    d2 = -(Md - Dd / 2) ** 2 + Mx**2 + My**2
+    (y1, y2) = _solve_quadratic(a2, b2, d2)
+
+    # Case A: Dx >= 2|Mx| — both sqrt formulas in (1)-(2) apply.
+    if (y2 <= x2) and (x1 <= y2):
+        Dx = y2
+    elif (x2 <= y2) and (y1 <= x2):
+        Dx = x2
+    else:
+        return None
+
+    Dy = Dx / c
+
+    if Dx >= 2 * abs(Mx):
+        return (Dx, Dy)
+
+    # Case B: Mx < 0, Dx < 2|Mx| — Max constraint becomes linear.
+    if Mx < 0:
+        z = (Md + Dd / 2 - abs(My)) * 2 * c
+        if y2 <= z:
+            Dx = y2
+        elif y1 <= z:
+            Dx = z
+        else:
+            Dx = None
+    # Case C: Mx > 0, Dx < 2Mx — Min constraint becomes linear.
+    elif Mx > 0:
+        z = (Dd / 2 - Md - abs(My)) * 2 * c
+        if x2 <= z:
+            Dx = x2
+        elif x1 <= z:
+            Dx = z
+        else:
+            Dx = None
+
+    if Dx is None or Dx < 0:
+        return None
+
+    Dy = Dx / c
+    return (Dx, Dy)
+
+
+def valid_image_given_detector_halfcircle(
+    M: tuple[float, float, float],
+    Dd: float,
+    c: float = 1.0,
+) -> tuple[float, float]:
+    """Smallest image so every ray hitting the detector passes through it.
+
+    Half-circle variant (phi in [0, pi]).  See PDF Section 3.3, Eqs. (13)-(14).
+
+    Parameters
+    ----------
+    M : (Md, Mx, My)
+        Detector center offset and image center coordinates.
+    Dd : float
+        Detector width.
+    c : float
+        Aspect ratio Dx / Dy.
+
+    Returns
+    -------
+    tuple[float, float]
+        Image dimensions (Dx, Dy).
+    """
+    (Md, Mx, My) = M
+
+    Dx = 2 * max(Mx - Md + Dd / 2, -Mx + Md + Dd / 2)
+    Dy = 2 * max(abs(Md) + Dd / 2 - My, abs(Md) + Dd / 2 + My)
+
+    Dx = max(Dx, c * Dy)
+    Dy = Dx / c
+    return (Dx, Dy)
+
+
+def valid_detector_given_image_halfcircle(
+    M: tuple[float, float, float],
+    D: tuple[float, float],
+) -> float | None:
+    """Largest detector so every ray hitting it passes through the image.
+
+    Half-circle variant (phi in [0, pi]).  See PDF Section 3.4, Eq. (15).
+
+    Parameters
+    ----------
+    M : (Md, Mx, My)
+        Detector center offset and image center coordinates.
+    D : (Dx, Dy)
+        Physical image dimensions.
+
+    Returns
+    -------
+    float or None
+        Detector width Dd, or None if no valid geometry exists.
+    """
+    (Md, Mx, My) = M
+    (Dx, Dy) = D
+
+    Dd = 2 * min(
+        -Mx + Dx / 2 + Md,
+        Mx - Md + Dx / 2,
+        My - abs(Md) + Dy / 2,
+        -My - abs(Md) + Dy / 2,
+    )
+    if Dd <= 0:
+        return None
+    return Dd

--- a/gratopy/utilities.py
+++ b/gratopy/utilities.py
@@ -318,8 +318,14 @@ class ImageDomain:
 
 
 def _solve_quadratic(a: float, b: float, d: float) -> tuple[float, float]:
-    """Solve ax^2 + bx + d = 0 and return (x1, x2) with x1 <= x2."""
+    """Solve ax^2 + bx + d = 0 and return (x1, x2) with x1 <= x2.
+
+    Returns (nan, nan) when no real roots exist; callers handle this via
+    the downstream NaN comparisons (always False).
+    """
     discriminant = b**2 - 4 * a * d
+    if discriminant < 0:
+        return (float("nan"), float("nan"))
     sqrt_disc = np.sqrt(discriminant)
     x1 = (-b - sqrt_disc) / (2 * a)
     x2 = (-b + sqrt_disc) / (2 * a)
@@ -393,6 +399,14 @@ def full_image_given_detector_halfcircle(
     """
     (Md, Mx, My) = M
 
+    # Half-circle point-image feasibility: s_center(phi) over phi in [0, pi]
+    # ranges over [-|My|, r] for Mx>=0 and [-r, |My|] for Mx<0, where
+    # r = sqrt(Mx^2 + My^2). Both endpoints must lie inside [Md-Dd/2, Md+Dd/2].
+    r = np.sqrt(Mx**2 + My**2)
+    s = 1.0 if Mx >= 0 else -1.0
+    if r > s * Md + Dd / 2 or abs(My) > Dd / 2 - s * Md:
+        return None
+
     a1 = (1 + c**2) / (4 * c**2)
     b1 = abs(My) / c + Mx
     d1 = -(Md + Dd / 2) ** 2 + Mx**2 + My**2
@@ -404,17 +418,14 @@ def full_image_given_detector_halfcircle(
     (y1, y2) = _solve_quadratic(a2, b2, d2)
 
     # Case A: Dx >= 2|Mx| — both sqrt formulas in (1)-(2) apply.
+    Dx = None
     if (y2 <= x2) and (x1 <= y2):
         Dx = y2
     elif (x2 <= y2) and (y1 <= x2):
         Dx = x2
-    else:
-        return None
 
-    Dy = Dx / c
-
-    if Dx >= 2 * abs(Mx):
-        return (Dx, Dy)
+    if Dx is not None and Dx >= 2 * abs(Mx):
+        return (Dx, Dx / c)
 
     # Case B: Mx < 0, Dx < 2|Mx| — Max constraint becomes linear.
     if Mx < 0:
@@ -434,6 +445,9 @@ def full_image_given_detector_halfcircle(
             Dx = z
         else:
             Dx = None
+    else:
+        # Mx == 0: rectangle always straddles x=0, Case A is the only path.
+        return None
 
     if Dx is None or Dx < 0:
         return None

--- a/gratopy/utilities.py
+++ b/gratopy/utilities.py
@@ -440,12 +440,12 @@ def full_image_given_detector_halfcircle(
 
     a1 = (1 + c**2) / (4 * c**2)
     b1 = abs(My) / c + Mx
-    d1 = -(Md + Dd / 2) ** 2 + Mx**2 + My**2
+    d1 = -((Md + Dd / 2) ** 2) + Mx**2 + My**2
     (x1, x2) = _solve_quadratic(a1, b1, d1)
 
     a2 = (1 + c**2) / (4 * c**2)
     b2 = abs(My) / c - Mx
-    d2 = -(Md - Dd / 2) ** 2 + Mx**2 + My**2
+    d2 = -((Md - Dd / 2) ** 2) + Mx**2 + My**2
     (y1, y2) = _solve_quadratic(a2, b2, d2)
 
     # Case A: Dx >= 2|Mx| — both sqrt formulas in (1)-(2) apply.

--- a/gratopy/utilities.py
+++ b/gratopy/utilities.py
@@ -20,8 +20,10 @@ class ExtentPlaceholder(Enum):
     They express geometric intent rather than an immediate numerical value.
 
     The placeholder mechanism in the experimental operator API is still
-    evolving. At the moment, placeholders should be considered unsupported in
-    the operator API and may raise :class:`NotImplementedError`.
+    evolving. The experimental Radon operator can resolve one placeholder
+    extent at a time: either the image extent from a fixed detector extent, or
+    the detector extent from a fixed image extent. Passing placeholders for
+    both extents at once is unsupported and raises :class:`NotImplementedError`.
     """
 
     FULL = "full"
@@ -275,8 +277,10 @@ class Detectors:
 
     **Notes**
 
-    In the current operator API, placeholder-based extent handling is not yet
-    implemented and may raise :class:`NotImplementedError`.
+    In the experimental Radon operator, ``ExtentPlaceholder.FULL`` and
+    ``ExtentPlaceholder.VALID`` can be used here to resolve the detector extent
+    from a fixed image extent. Passing placeholders for both detector and image
+    extents at once is unsupported and raises :class:`NotImplementedError`.
     """
 
     number: int
@@ -322,8 +326,11 @@ class ImageDomain:
 
     **Notes**
 
-    In the experimental operator API, placeholders for extents are not yet
-    implemented and may raise :class:`NotImplementedError`.
+    In the experimental Radon operator, ``ExtentPlaceholder.FULL`` and
+    ``ExtentPlaceholder.VALID`` can be used here to resolve the image extent
+    from a fixed detector extent. Passing placeholders for both image and
+    detector extents at once is unsupported and raises
+    :class:`NotImplementedError`.
     """
 
     size: tuple[int, int]

--- a/gratopy/utilities.py
+++ b/gratopy/utilities.py
@@ -363,6 +363,41 @@ def _solve_quadratic(a: float, b: float, d: float) -> tuple[float, float]:
     return (x1, x2)
 
 
+def _select_extent_from_linear_case(
+    lower_root: float, upper_root: float, linear_bound: float
+) -> float | None:
+    """Select the image extent in one of the linear half-circle cases."""
+    if upper_root <= linear_bound:
+        return upper_root
+    if lower_root <= linear_bound:
+        return linear_bound
+    return None
+
+
+def _point_image_fits_detector_halfcircle(
+    M: tuple[float, float, float], Dd: float
+) -> bool:
+    """Return whether a point image at ``(Mx, My)`` fits into the detector."""
+    (Md, Mx, My) = M
+    # Half-circle point-image feasibility: s_center(phi) over phi in [0, pi]
+    # ranges over [-|My|, r] for Mx>=0 and [-r, |My|] for Mx<0, where
+    # r = sqrt(Mx^2 + My^2). Both endpoints must lie inside [Md-Dd/2, Md+Dd/2].
+    r = np.sqrt(Mx**2 + My**2)
+    s = 1.0 if Mx >= 0 else -1.0
+    return r <= s * Md + Dd / 2 and abs(My) <= Dd / 2 - s * Md
+
+
+def _select_extent_from_case_a(
+    x1: float, x2: float, y1: float, y2: float
+) -> float | None:
+    """Select the image extent where both sqrt constraints apply."""
+    if (y2 <= x2) and (x1 <= y2):
+        return y2
+    if (x2 <= y2) and (y1 <= x2):
+        return x2
+    return None
+
+
 def full_detector_given_image_halfcircle(
     M: tuple[float, float, float],
     D: tuple[float, float],
@@ -430,12 +465,7 @@ def full_image_given_detector_halfcircle(
     """
     (Md, Mx, My) = M
 
-    # Half-circle point-image feasibility: s_center(phi) over phi in [0, pi]
-    # ranges over [-|My|, r] for Mx>=0 and [-r, |My|] for Mx<0, where
-    # r = sqrt(Mx^2 + My^2). Both endpoints must lie inside [Md-Dd/2, Md+Dd/2].
-    r = np.sqrt(Mx**2 + My**2)
-    s = 1.0 if Mx >= 0 else -1.0
-    if r > s * Md + Dd / 2 or abs(My) > Dd / 2 - s * Md:
+    if not _point_image_fits_detector_halfcircle(M, Dd):
         return None
 
     a1 = (1 + c**2) / (4 * c**2)
@@ -448,34 +478,23 @@ def full_image_given_detector_halfcircle(
     d2 = -((Md - Dd / 2) ** 2) + Mx**2 + My**2
     (y1, y2) = _solve_quadratic(a2, b2, d2)
 
-    # Case A: Dx >= 2|Mx| — both sqrt formulas in (1)-(2) apply.
-    Dx = None
-    if (y2 <= x2) and (x1 <= y2):
-        Dx = y2
-    elif (x2 <= y2) and (y1 <= x2):
-        Dx = x2
+    # Case A: the image interval crosses the rotation center in x-direction
+    # (Dx >= 2|Mx|), so both extrema are given by the sqrt formulas (1)-(2).
+    Dx = _select_extent_from_case_a(x1, x2, y1, y2)
 
     if Dx is not None and Dx >= 2 * abs(Mx):
         return (Dx, Dx / c)
 
-    # Case B: Mx < 0, Dx < 2|Mx| — Max constraint becomes linear.
+    # Case B: the image lies to the negative x side (Mx < 0, Dx < 2|Mx|),
+    # so the upper detector constraint becomes linear.
     if Mx < 0:
         z = (Md + Dd / 2 - abs(My)) * 2 * c
-        if y2 <= z:
-            Dx = y2
-        elif y1 <= z:
-            Dx = z
-        else:
-            Dx = None
-    # Case C: Mx > 0, Dx < 2Mx — Min constraint becomes linear.
+        Dx = _select_extent_from_linear_case(y1, y2, z)
+    # Case C: the image lies to the positive x side (Mx > 0, Dx < 2Mx),
+    # so the lower detector constraint becomes linear.
     elif Mx > 0:
         z = (Dd / 2 - Md - abs(My)) * 2 * c
-        if x2 <= z:
-            Dx = x2
-        elif x1 <= z:
-            Dx = z
-        else:
-            Dx = None
+        Dx = _select_extent_from_linear_case(x1, x2, z)
     else:
         # Mx == 0: rectangle always straddles x=0, Case A is the only path.
         return None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -116,7 +116,7 @@ def create_phantoms(queue, N, dtype: str | np.typing.DTypeLike = "double", order
 
     # use gratopy phantom method to create Shepp-Logan phantom
     A = gratopy.phantom(queue, N, dtype=dtype)
-    A *= 255 / clarray.max(A).get()
+    A *= dtype.type(255) / clarray.max(A).get()
 
     # second test image consisting of 2 horizontal bars
     B = clarray.empty(queue, A.shape, dtype=dtype)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -114,6 +114,8 @@ def evaluate_control_numbers(
 def create_phantoms(queue, N, dtype: str | np.typing.DTypeLike = "double", order="F"):
     # Create a phantom image which is used in many of the tests that follow
 
+    dtype = np.dtype(dtype)
+
     # use gratopy phantom method to create Shepp-Logan phantom
     A = gratopy.phantom(queue, N, dtype=dtype)
     A *= dtype.type(255) / clarray.max(A).get()

--- a/tests/test_extent_placeholder.py
+++ b/tests/test_extent_placeholder.py
@@ -1,0 +1,218 @@
+"""Tests for ExtentPlaceholder resolution in the Radon operator.
+
+These tests verify that ExtentPlaceholder.FULL and ExtentPlaceholder.VALID
+are correctly resolved to concrete float values when constructing a Radon
+operator with one placeholder extent and one fixed extent.
+
+The tests cover both directions:
+- Fixed image extent, placeholder on the detector side.
+- Fixed detector extent, placeholder on the image side.
+
+Each direction is tested across a range of image and detector center
+offsets to exercise the geometry formulas for off-center configurations.
+
+Expected reference values were computed independently and are compared
+with a tolerance of 0.02 to account for discretization effects.
+"""
+
+import numpy as np
+import pytest
+import pyopencl as cl
+
+from gratopy.operator import Radon
+from gratopy.utilities import Detectors, ExtentPlaceholder, ImageDomain
+
+
+ctx = cl.create_some_context(interactive=False)
+queue = cl.CommandQueue(ctx)
+
+Nx = 400
+Ns = 100
+Na = 180
+
+IMAGE_CENTERS = [
+    (+0.5, 0.2),
+    (-0.5, 0.2),
+    (0.5, -0.2),
+    (-0.5, -0.2),
+]
+
+DETECTOR_CENTERS = [0, 0.2, -0.2, 0.5, -0.5]
+
+
+# -- Detector placeholder with fixed image extent ---------------------------
+
+DETECTOR_PLACEHOLDER_EXPECTED = {
+    ExtentPlaceholder.VALID: [
+        # detector_center=0
+        1.0, 1.0, 1.0, 1.0,
+        # detector_center=0.2
+        1.2, 0.6, 1.2, 0.6,
+        # detector_center=-0.2
+        0.6, 1.2, 0.6, 1.2,
+        # detector_center=0.5
+        0.6, None, 0.6, None,
+        # detector_center=-0.5
+        None, 0.6, None, 0.6,
+    ],
+    ExtentPlaceholder.FULL: [
+        # detector_center=0
+        3.841, 3.841, 3.841, 3.841,
+        # detector_center=0.2
+        3.441, 4.241, 3.441, 4.241,
+        # detector_center=-0.2
+        4.241, 3.441, 4.241, 3.441,
+        # detector_center=0.5
+        3.6, 4.841, 3.6, 4.841,
+        # detector_center=-0.5
+        4.841, 3.6, 4.841, 3.6,
+    ],
+}
+
+
+def _detector_placeholder_cases():
+    """Generate (placeholder, detector_center, image_center, expected) tuples."""
+    for placeholder in [ExtentPlaceholder.VALID, ExtentPlaceholder.FULL]:
+        expected_list = list(DETECTOR_PLACEHOLDER_EXPECTED[placeholder])
+        idx = 0
+        for dc in DETECTOR_CENTERS:
+            for ic in IMAGE_CENTERS:
+                yield placeholder, dc, ic, expected_list[idx]
+                idx += 1
+
+
+@pytest.mark.parametrize(
+    "placeholder, detector_center, image_center, expected",
+    list(_detector_placeholder_cases()),
+    ids=[
+        f"{p.name}-dc{dc}-ic{ic}"
+        for p in [ExtentPlaceholder.VALID, ExtentPlaceholder.FULL]
+        for dc in DETECTOR_CENTERS
+        for ic in IMAGE_CENTERS
+    ],
+)
+def test_detector_extent_placeholder(
+    placeholder, detector_center, image_center, expected
+):
+    """Resolve a detector ExtentPlaceholder with a fixed image extent of 2.0.
+
+    Verifies that the resolved detector extent matches the independently
+    computed reference value. Cases where no valid geometry exists (expected
+    is None) must raise a ValueError.
+    """
+    if expected is None:
+        with pytest.raises(ValueError):
+            Radon(
+                image_domain=ImageDomain(
+                    size=Nx, center=image_center, extent=2.0
+                ),
+                angles=Na,
+                detectors=Detectors(
+                    number=Ns, center=detector_center, extent=placeholder
+                ),
+            )
+    else:
+        radon = Radon(
+            image_domain=ImageDomain(
+                size=Nx, center=image_center, extent=2.0
+            ),
+            angles=Na,
+            detectors=Detectors(
+                number=Ns, center=detector_center, extent=placeholder
+            ),
+        )
+        assert isinstance(radon.detectors.extent, float)
+        assert radon.detectors.extent == pytest.approx(expected, abs=0.02), (
+            f"Detector extent mismatch for {placeholder.name} with "
+            f"detector_center={detector_center}, image_center={image_center}: "
+            f"expected {expected}, got {radon.detectors.extent}"
+        )
+
+
+# -- Image placeholder with fixed detector extent ---------------------------
+
+IMAGE_PLACEHOLDER_EXPECTED = {
+    ExtentPlaceholder.VALID: [
+        # detector_center=0
+        3.0, 3.0, 3.0, 3.0,
+        # detector_center=0.2
+        2.8, 3.4, 2.8, 3.4,
+        # detector_center=-0.2
+        3.4, 2.8, 3.4, 2.8,
+        # detector_center=0.5
+        3.4, 4.0, 3.4, 4.0,
+        # detector_center=-0.5
+        4.0, 3.4, 4.0, 3.4,
+    ],
+    ExtentPlaceholder.FULL: [
+        # detector_center=0
+        0.682, 0.682, 0.682, 0.682,
+        # detector_center=0.2
+        0.970, 0.390, 0.970, 0.390,
+        # detector_center=-0.2
+        0.390, 0.970, 0.390, 0.970,
+        # detector_center=0.5
+        0.6, None, 0.6, None,
+        # detector_center=-0.5
+        None, 0.6, None, 0.6,
+    ],
+}
+
+
+def _image_placeholder_cases():
+    """Generate (placeholder, detector_center, image_center, expected) tuples."""
+    for placeholder in [ExtentPlaceholder.VALID, ExtentPlaceholder.FULL]:
+        expected_list = list(IMAGE_PLACEHOLDER_EXPECTED[placeholder])
+        idx = 0
+        for dc in DETECTOR_CENTERS:
+            for ic in IMAGE_CENTERS:
+                yield placeholder, dc, ic, expected_list[idx]
+                idx += 1
+
+
+@pytest.mark.parametrize(
+    "placeholder, detector_center, image_center, expected",
+    list(_image_placeholder_cases()),
+    ids=[
+        f"{p.name}-dc{dc}-ic{ic}"
+        for p in [ExtentPlaceholder.VALID, ExtentPlaceholder.FULL]
+        for dc in DETECTOR_CENTERS
+        for ic in IMAGE_CENTERS
+    ],
+)
+def test_image_extent_placeholder(
+    placeholder, detector_center, image_center, expected
+):
+    """Resolve an image ExtentPlaceholder with a fixed detector extent of 2.0.
+
+    Verifies that the resolved image extent matches the independently
+    computed reference value. Cases where no valid geometry exists (expected
+    is None) must raise a ValueError.
+    """
+    if expected is None:
+        with pytest.raises(ValueError):
+            Radon(
+                image_domain=ImageDomain(
+                    size=Nx, center=image_center, extent=placeholder
+                ),
+                angles=Na,
+                detectors=Detectors(
+                    number=Ns, center=detector_center, extent=2.0
+                ),
+            )
+    else:
+        radon = Radon(
+            image_domain=ImageDomain(
+                size=Nx, center=image_center, extent=placeholder
+            ),
+            angles=Na,
+            detectors=Detectors(
+                number=Ns, center=detector_center, extent=2.0
+            ),
+        )
+        assert isinstance(radon.image_domain.extent, float)
+        assert radon.image_domain.extent == pytest.approx(expected, abs=0.02), (
+            f"Image extent mismatch for {placeholder.name} with "
+            f"detector_center={detector_center}, image_center={image_center}: "
+            f"expected {expected}, got {radon.image_domain.extent}"
+        )

--- a/tests/test_extent_placeholder.py
+++ b/tests/test_extent_placeholder.py
@@ -19,14 +19,10 @@ regression guards. Comparison uses an absolute tolerance of 0.02.
 """
 
 import pytest
-import pyopencl as cl
 
 from gratopy.operator import Radon
 from gratopy.utilities import Detectors, ExtentPlaceholder, ImageDomain
 
-
-ctx = cl.create_some_context(interactive=False)
-queue = cl.CommandQueue(ctx)
 
 Nx = 400
 Ns = 100

--- a/tests/test_extent_placeholder.py
+++ b/tests/test_extent_placeholder.py
@@ -8,14 +8,16 @@ The tests cover both directions:
 - Fixed image extent, placeholder on the detector side.
 - Fixed detector extent, placeholder on the image side.
 
-Each direction is tested across a range of image and detector center
-offsets to exercise the geometry formulas for off-center configurations.
+Each direction is exercised across a range of image and detector center
+offsets and across image side ratios Ny/Nx in {0.7, 1.0, 1.7} to cover
+non-square image domains (c = Nx/Ny != 1).
 
-Expected reference values were computed independently and are compared
-with a tolerance of 0.02 to account for discretization effects.
+Reference values for the c=1 cases were computed independently by hand;
+the c!=1 cases were captured from the implementation after visual
+verification of the underlying radon transforms, so they act as
+regression guards. Comparison uses an absolute tolerance of 0.02.
 """
 
-import numpy as np
 import pytest
 import pyopencl as cl
 
@@ -39,72 +41,125 @@ IMAGE_CENTERS = [
 
 DETECTOR_CENTERS = [0, 0.2, -0.2, 0.5, -0.5]
 
+SIDE_RATIOS = [0.7, 1.0, 1.7]
+
 
 # -- Detector placeholder with fixed image extent ---------------------------
 
 DETECTOR_PLACEHOLDER_EXPECTED = {
-    ExtentPlaceholder.VALID: [
+    (ExtentPlaceholder.VALID, 0.7): [
         # detector_center=0
-        1.0, 1.0, 1.0, 1.0,
+        1.000, 1.000, 1.000, 1.000,
         # detector_center=0.2
-        1.2, 0.6, 1.2, 0.6,
+        0.600, 0.600, 0.600, 0.600,
         # detector_center=-0.2
-        0.6, 1.2, 0.6, 1.2,
+        0.600, 0.600, 0.600, 0.600,
         # detector_center=0.5
-        0.6, None, 0.6, None,
+        None, None, None, None,
         # detector_center=-0.5
-        None, 0.6, None, 0.6,
+        None, None, None, None,
     ],
-    ExtentPlaceholder.FULL: [
+    (ExtentPlaceholder.VALID, 1.0): [
         # detector_center=0
-        3.841, 3.841, 3.841, 3.841,
+        1.000, 1.000, 1.000, 1.000,
         # detector_center=0.2
-        3.441, 4.241, 3.441, 4.241,
+        1.200, 0.600, 1.200, 0.600,
         # detector_center=-0.2
-        4.241, 3.441, 4.241, 3.441,
+        0.600, 1.200, 0.600, 1.200,
         # detector_center=0.5
-        3.6, 4.841, 3.6, 4.841,
+        0.600, None, 0.600, None,
         # detector_center=-0.5
-        4.841, 3.6, 4.841, 3.6,
+        None, 0.600, None, 0.600,
+    ],
+    (ExtentPlaceholder.VALID, 1.7): [
+        # detector_center=0
+        0.176, 0.176, 0.176, 0.176,
+        # detector_center=0.2
+        0.576, None, 0.576, None,
+        # detector_center=-0.2
+        None, 0.576, None, 0.576,
+        # detector_center=0.5
+        0.600, None, 0.600, None,
+        # detector_center=-0.5
+        None, 0.600, None, 0.600,
+    ],
+    (ExtentPlaceholder.FULL, 0.7): [
+        # detector_center=0
+        3.499, 3.499, 3.499, 3.499,
+        # detector_center=0.2
+        3.099, 3.899, 3.099, 3.899,
+        # detector_center=-0.2
+        3.899, 3.099, 3.899, 3.099,
+        # detector_center=0.5
+        3.059, 4.499, 3.059, 4.499,
+        # detector_center=-0.5
+        4.499, 3.059, 4.499, 3.059,
+    ],
+    (ExtentPlaceholder.FULL, 1.0): [
+        # detector_center=0
+        3.842, 3.842, 3.842, 3.842,
+        # detector_center=0.2
+        3.442, 4.242, 3.442, 4.242,
+        # detector_center=-0.2
+        4.242, 3.442, 4.242, 3.442,
+        # detector_center=0.5
+        3.600, 4.842, 3.600, 4.842,
+        # detector_center=-0.5
+        4.842, 3.600, 4.842, 3.600,
+    ],
+    (ExtentPlaceholder.FULL, 1.7): [
+        # detector_center=0
+        3.240, 3.240, 3.240, 3.240,
+        # detector_center=0.2
+        2.840, 3.640, 2.840, 3.640,
+        # detector_center=-0.2
+        3.640, 2.840, 3.640, 2.840,
+        # detector_center=0.5
+        3.406, 4.240, 3.406, 4.240,
+        # detector_center=-0.5
+        4.240, 3.406, 4.240, 3.406,
     ],
 }
 
 
 def _detector_placeholder_cases():
-    """Generate (placeholder, detector_center, image_center, expected) tuples."""
+    """Yield (placeholder, side_ratio, detector_center, image_center, expected)."""
     for placeholder in [ExtentPlaceholder.VALID, ExtentPlaceholder.FULL]:
-        expected_list = list(DETECTOR_PLACEHOLDER_EXPECTED[placeholder])
-        idx = 0
-        for dc in DETECTOR_CENTERS:
-            for ic in IMAGE_CENTERS:
-                yield placeholder, dc, ic, expected_list[idx]
-                idx += 1
+        for sr in SIDE_RATIOS:
+            expected_list = list(DETECTOR_PLACEHOLDER_EXPECTED[(placeholder, sr)])
+            idx = 0
+            for dc in DETECTOR_CENTERS:
+                for ic in IMAGE_CENTERS:
+                    yield placeholder, sr, dc, ic, expected_list[idx]
+                    idx += 1
 
 
 @pytest.mark.parametrize(
-    "placeholder, detector_center, image_center, expected",
+    "placeholder, side_ratio, detector_center, image_center, expected",
     list(_detector_placeholder_cases()),
     ids=[
-        f"{p.name}-dc{dc}-ic{ic}"
+        f"{p.name}-sr{sr}-dc{dc}-ic{ic}"
         for p in [ExtentPlaceholder.VALID, ExtentPlaceholder.FULL]
+        for sr in SIDE_RATIOS
         for dc in DETECTOR_CENTERS
         for ic in IMAGE_CENTERS
     ],
 )
 def test_detector_extent_placeholder(
-    placeholder, detector_center, image_center, expected
+    placeholder, side_ratio, detector_center, image_center, expected
 ):
     """Resolve a detector ExtentPlaceholder with a fixed image extent of 2.0.
 
-    Verifies that the resolved detector extent matches the independently
-    computed reference value. Cases where no valid geometry exists (expected
-    is None) must raise a ValueError.
+    Verifies that the resolved detector extent matches the reference value.
+    Cases where no valid geometry exists (expected is None) must raise a
+    ValueError.
     """
+    Ny = int(side_ratio * Nx)
     if expected is None:
         with pytest.raises(ValueError):
             Radon(
                 image_domain=ImageDomain(
-                    size=Nx, center=image_center, extent=2.0
+                    size=(Nx, Ny), center=image_center, extent=2.0
                 ),
                 angles=Na,
                 detectors=Detectors(
@@ -114,7 +169,7 @@ def test_detector_extent_placeholder(
     else:
         radon = Radon(
             image_domain=ImageDomain(
-                size=Nx, center=image_center, extent=2.0
+                size=(Nx, Ny), center=image_center, extent=2.0
             ),
             angles=Na,
             detectors=Detectors(
@@ -124,7 +179,8 @@ def test_detector_extent_placeholder(
         assert isinstance(radon.detectors.extent, float)
         assert radon.detectors.extent == pytest.approx(expected, abs=0.02), (
             f"Detector extent mismatch for {placeholder.name} with "
-            f"detector_center={detector_center}, image_center={image_center}: "
+            f"side_ratio={side_ratio}, detector_center={detector_center}, "
+            f"image_center={image_center}: "
             f"expected {expected}, got {radon.detectors.extent}"
         )
 
@@ -132,68 +188,119 @@ def test_detector_extent_placeholder(
 # -- Image placeholder with fixed detector extent ---------------------------
 
 IMAGE_PLACEHOLDER_EXPECTED = {
-    ExtentPlaceholder.VALID: [
+    (ExtentPlaceholder.VALID, 0.7): [
         # detector_center=0
-        3.0, 3.0, 3.0, 3.0,
+        3.429, 3.429, 3.429, 3.429,
         # detector_center=0.2
-        2.8, 3.4, 2.8, 3.4,
+        4.000, 4.000, 4.000, 4.000,
         # detector_center=-0.2
-        3.4, 2.8, 3.4, 2.8,
+        4.000, 4.000, 4.000, 4.000,
         # detector_center=0.5
-        3.4, 4.0, 3.4, 4.0,
+        4.857, 4.857, 4.857, 4.857,
         # detector_center=-0.5
-        4.0, 3.4, 4.0, 3.4,
+        4.857, 4.857, 4.857, 4.857,
     ],
-    ExtentPlaceholder.FULL: [
+    (ExtentPlaceholder.VALID, 1.0): [
+        # detector_center=0
+        3.000, 3.000, 3.000, 3.000,
+        # detector_center=0.2
+        2.800, 3.400, 2.800, 3.400,
+        # detector_center=-0.2
+        3.400, 2.800, 3.400, 2.800,
+        # detector_center=0.5
+        3.400, 4.000, 3.400, 4.000,
+        # detector_center=-0.5
+        4.000, 3.400, 4.000, 3.400,
+    ],
+    (ExtentPlaceholder.VALID, 1.7): [
+        # detector_center=0
+        5.100, 5.100, 5.100, 5.100,
+        # detector_center=0.2
+        4.420, 5.780, 4.420, 5.780,
+        # detector_center=-0.2
+        5.780, 4.420, 5.780, 4.420,
+        # detector_center=0.5
+        3.400, 6.800, 3.400, 6.800,
+        # detector_center=-0.5
+        6.800, 3.400, 6.800, 3.400,
+    ],
+    (ExtentPlaceholder.FULL, 0.7): [
+        # detector_center=0
+        0.767, 0.767, 0.767, 0.767,
+        # detector_center=0.2
+        1.097, 0.436, 1.097, 0.436,
+        # detector_center=-0.2
+        0.436, 1.097, 0.436, 1.097,
+        # detector_center=0.5
+        0.857, None, 0.857, None,
+        # detector_center=-0.5
+        None, 0.857, None, 0.857,
+    ],
+    (ExtentPlaceholder.FULL, 1.0): [
         # detector_center=0
         0.682, 0.682, 0.682, 0.682,
         # detector_center=0.2
-        0.970, 0.390, 0.970, 0.390,
+        0.970, 0.391, 0.970, 0.391,
         # detector_center=-0.2
-        0.390, 0.970, 0.390, 0.970,
+        0.391, 0.970, 0.391, 0.970,
         # detector_center=0.5
-        0.6, None, 0.6, None,
+        0.600, None, 0.600, None,
         # detector_center=-0.5
-        None, 0.6, None, 0.6,
+        None, 0.600, None, 0.600,
+    ],
+    (ExtentPlaceholder.FULL, 1.7): [
+        # detector_center=0
+        0.893, 0.893, 0.893, 0.893,
+        # detector_center=0.2
+        1.200, 0.522, 1.200, 0.522,
+        # detector_center=-0.2
+        0.522, 1.200, 0.522, 1.200,
+        # detector_center=0.5
+        0.600, None, 0.600, None,
+        # detector_center=-0.5
+        None, 0.600, None, 0.600,
     ],
 }
 
 
 def _image_placeholder_cases():
-    """Generate (placeholder, detector_center, image_center, expected) tuples."""
+    """Yield (placeholder, side_ratio, detector_center, image_center, expected)."""
     for placeholder in [ExtentPlaceholder.VALID, ExtentPlaceholder.FULL]:
-        expected_list = list(IMAGE_PLACEHOLDER_EXPECTED[placeholder])
-        idx = 0
-        for dc in DETECTOR_CENTERS:
-            for ic in IMAGE_CENTERS:
-                yield placeholder, dc, ic, expected_list[idx]
-                idx += 1
+        for sr in SIDE_RATIOS:
+            expected_list = list(IMAGE_PLACEHOLDER_EXPECTED[(placeholder, sr)])
+            idx = 0
+            for dc in DETECTOR_CENTERS:
+                for ic in IMAGE_CENTERS:
+                    yield placeholder, sr, dc, ic, expected_list[idx]
+                    idx += 1
 
 
 @pytest.mark.parametrize(
-    "placeholder, detector_center, image_center, expected",
+    "placeholder, side_ratio, detector_center, image_center, expected",
     list(_image_placeholder_cases()),
     ids=[
-        f"{p.name}-dc{dc}-ic{ic}"
+        f"{p.name}-sr{sr}-dc{dc}-ic{ic}"
         for p in [ExtentPlaceholder.VALID, ExtentPlaceholder.FULL]
+        for sr in SIDE_RATIOS
         for dc in DETECTOR_CENTERS
         for ic in IMAGE_CENTERS
     ],
 )
 def test_image_extent_placeholder(
-    placeholder, detector_center, image_center, expected
+    placeholder, side_ratio, detector_center, image_center, expected
 ):
     """Resolve an image ExtentPlaceholder with a fixed detector extent of 2.0.
 
-    Verifies that the resolved image extent matches the independently
-    computed reference value. Cases where no valid geometry exists (expected
-    is None) must raise a ValueError.
+    Verifies that the resolved image extent matches the reference value.
+    Cases where no valid geometry exists (expected is None) must raise a
+    ValueError.
     """
+    Ny = int(side_ratio * Nx)
     if expected is None:
         with pytest.raises(ValueError):
             Radon(
                 image_domain=ImageDomain(
-                    size=Nx, center=image_center, extent=placeholder
+                    size=(Nx, Ny), center=image_center, extent=placeholder
                 ),
                 angles=Na,
                 detectors=Detectors(
@@ -203,7 +310,7 @@ def test_image_extent_placeholder(
     else:
         radon = Radon(
             image_domain=ImageDomain(
-                size=Nx, center=image_center, extent=placeholder
+                size=(Nx, Ny), center=image_center, extent=placeholder
             ),
             angles=Na,
             detectors=Detectors(
@@ -213,6 +320,7 @@ def test_image_extent_placeholder(
         assert isinstance(radon.image_domain.extent, float)
         assert radon.image_domain.extent == pytest.approx(expected, abs=0.02), (
             f"Image extent mismatch for {placeholder.name} with "
-            f"detector_center={detector_center}, image_center={image_center}: "
+            f"side_ratio={side_ratio}, detector_center={detector_center}, "
+            f"image_center={image_center}: "
             f"expected {expected}, got {radon.image_domain.extent}"
         )

--- a/tests/test_extent_placeholder.py
+++ b/tests/test_extent_placeholder.py
@@ -49,75 +49,165 @@ SIDE_RATIOS = [0.7, 1.0, 1.7]
 DETECTOR_PLACEHOLDER_EXPECTED = {
     (ExtentPlaceholder.VALID, 0.7): [
         # detector_center=0
-        1.000, 1.000, 1.000, 1.000,
+        1.000,
+        1.000,
+        1.000,
+        1.000,
         # detector_center=0.2
-        0.600, 0.600, 0.600, 0.600,
+        0.600,
+        0.600,
+        0.600,
+        0.600,
         # detector_center=-0.2
-        0.600, 0.600, 0.600, 0.600,
+        0.600,
+        0.600,
+        0.600,
+        0.600,
         # detector_center=0.5
-        None, None, None, None,
+        None,
+        None,
+        None,
+        None,
         # detector_center=-0.5
-        None, None, None, None,
+        None,
+        None,
+        None,
+        None,
     ],
     (ExtentPlaceholder.VALID, 1.0): [
         # detector_center=0
-        1.000, 1.000, 1.000, 1.000,
+        1.000,
+        1.000,
+        1.000,
+        1.000,
         # detector_center=0.2
-        1.200, 0.600, 1.200, 0.600,
+        1.200,
+        0.600,
+        1.200,
+        0.600,
         # detector_center=-0.2
-        0.600, 1.200, 0.600, 1.200,
+        0.600,
+        1.200,
+        0.600,
+        1.200,
         # detector_center=0.5
-        0.600, None, 0.600, None,
+        0.600,
+        None,
+        0.600,
+        None,
         # detector_center=-0.5
-        None, 0.600, None, 0.600,
+        None,
+        0.600,
+        None,
+        0.600,
     ],
     (ExtentPlaceholder.VALID, 1.7): [
         # detector_center=0
-        0.176, 0.176, 0.176, 0.176,
+        0.176,
+        0.176,
+        0.176,
+        0.176,
         # detector_center=0.2
-        0.576, None, 0.576, None,
+        0.576,
+        None,
+        0.576,
+        None,
         # detector_center=-0.2
-        None, 0.576, None, 0.576,
+        None,
+        0.576,
+        None,
+        0.576,
         # detector_center=0.5
-        0.600, None, 0.600, None,
+        0.600,
+        None,
+        0.600,
+        None,
         # detector_center=-0.5
-        None, 0.600, None, 0.600,
+        None,
+        0.600,
+        None,
+        0.600,
     ],
     (ExtentPlaceholder.FULL, 0.7): [
         # detector_center=0
-        3.499, 3.499, 3.499, 3.499,
+        3.499,
+        3.499,
+        3.499,
+        3.499,
         # detector_center=0.2
-        3.099, 3.899, 3.099, 3.899,
+        3.099,
+        3.899,
+        3.099,
+        3.899,
         # detector_center=-0.2
-        3.899, 3.099, 3.899, 3.099,
+        3.899,
+        3.099,
+        3.899,
+        3.099,
         # detector_center=0.5
-        3.059, 4.499, 3.059, 4.499,
+        3.059,
+        4.499,
+        3.059,
+        4.499,
         # detector_center=-0.5
-        4.499, 3.059, 4.499, 3.059,
+        4.499,
+        3.059,
+        4.499,
+        3.059,
     ],
     (ExtentPlaceholder.FULL, 1.0): [
         # detector_center=0
-        3.842, 3.842, 3.842, 3.842,
+        3.842,
+        3.842,
+        3.842,
+        3.842,
         # detector_center=0.2
-        3.442, 4.242, 3.442, 4.242,
+        3.442,
+        4.242,
+        3.442,
+        4.242,
         # detector_center=-0.2
-        4.242, 3.442, 4.242, 3.442,
+        4.242,
+        3.442,
+        4.242,
+        3.442,
         # detector_center=0.5
-        3.600, 4.842, 3.600, 4.842,
+        3.600,
+        4.842,
+        3.600,
+        4.842,
         # detector_center=-0.5
-        4.842, 3.600, 4.842, 3.600,
+        4.842,
+        3.600,
+        4.842,
+        3.600,
     ],
     (ExtentPlaceholder.FULL, 1.7): [
         # detector_center=0
-        3.240, 3.240, 3.240, 3.240,
+        3.240,
+        3.240,
+        3.240,
+        3.240,
         # detector_center=0.2
-        2.840, 3.640, 2.840, 3.640,
+        2.840,
+        3.640,
+        2.840,
+        3.640,
         # detector_center=-0.2
-        3.640, 2.840, 3.640, 2.840,
+        3.640,
+        2.840,
+        3.640,
+        2.840,
         # detector_center=0.5
-        3.406, 4.240, 3.406, 4.240,
+        3.406,
+        4.240,
+        3.406,
+        4.240,
         # detector_center=-0.5
-        4.240, 3.406, 4.240, 3.406,
+        4.240,
+        3.406,
+        4.240,
+        3.406,
     ],
 }
 
@@ -158,9 +248,7 @@ def test_detector_extent_placeholder(
     if expected is None:
         with pytest.raises(ValueError):
             Radon(
-                image_domain=ImageDomain(
-                    size=(Nx, Ny), center=image_center, extent=2.0
-                ),
+                image_domain=ImageDomain(size=(Nx, Ny), center=image_center, extent=2.0),
                 angles=Na,
                 detectors=Detectors(
                     number=Ns, center=detector_center, extent=placeholder
@@ -168,13 +256,9 @@ def test_detector_extent_placeholder(
             )
     else:
         radon = Radon(
-            image_domain=ImageDomain(
-                size=(Nx, Ny), center=image_center, extent=2.0
-            ),
+            image_domain=ImageDomain(size=(Nx, Ny), center=image_center, extent=2.0),
             angles=Na,
-            detectors=Detectors(
-                number=Ns, center=detector_center, extent=placeholder
-            ),
+            detectors=Detectors(number=Ns, center=detector_center, extent=placeholder),
         )
         assert isinstance(radon.detectors.extent, float)
         assert radon.detectors.extent == pytest.approx(expected, abs=0.02), (
@@ -190,75 +274,165 @@ def test_detector_extent_placeholder(
 IMAGE_PLACEHOLDER_EXPECTED = {
     (ExtentPlaceholder.VALID, 0.7): [
         # detector_center=0
-        3.429, 3.429, 3.429, 3.429,
+        3.429,
+        3.429,
+        3.429,
+        3.429,
         # detector_center=0.2
-        4.000, 4.000, 4.000, 4.000,
+        4.000,
+        4.000,
+        4.000,
+        4.000,
         # detector_center=-0.2
-        4.000, 4.000, 4.000, 4.000,
+        4.000,
+        4.000,
+        4.000,
+        4.000,
         # detector_center=0.5
-        4.857, 4.857, 4.857, 4.857,
+        4.857,
+        4.857,
+        4.857,
+        4.857,
         # detector_center=-0.5
-        4.857, 4.857, 4.857, 4.857,
+        4.857,
+        4.857,
+        4.857,
+        4.857,
     ],
     (ExtentPlaceholder.VALID, 1.0): [
         # detector_center=0
-        3.000, 3.000, 3.000, 3.000,
+        3.000,
+        3.000,
+        3.000,
+        3.000,
         # detector_center=0.2
-        2.800, 3.400, 2.800, 3.400,
+        2.800,
+        3.400,
+        2.800,
+        3.400,
         # detector_center=-0.2
-        3.400, 2.800, 3.400, 2.800,
+        3.400,
+        2.800,
+        3.400,
+        2.800,
         # detector_center=0.5
-        3.400, 4.000, 3.400, 4.000,
+        3.400,
+        4.000,
+        3.400,
+        4.000,
         # detector_center=-0.5
-        4.000, 3.400, 4.000, 3.400,
+        4.000,
+        3.400,
+        4.000,
+        3.400,
     ],
     (ExtentPlaceholder.VALID, 1.7): [
         # detector_center=0
-        5.100, 5.100, 5.100, 5.100,
+        5.100,
+        5.100,
+        5.100,
+        5.100,
         # detector_center=0.2
-        4.420, 5.780, 4.420, 5.780,
+        4.420,
+        5.780,
+        4.420,
+        5.780,
         # detector_center=-0.2
-        5.780, 4.420, 5.780, 4.420,
+        5.780,
+        4.420,
+        5.780,
+        4.420,
         # detector_center=0.5
-        3.400, 6.800, 3.400, 6.800,
+        3.400,
+        6.800,
+        3.400,
+        6.800,
         # detector_center=-0.5
-        6.800, 3.400, 6.800, 3.400,
+        6.800,
+        3.400,
+        6.800,
+        3.400,
     ],
     (ExtentPlaceholder.FULL, 0.7): [
         # detector_center=0
-        0.767, 0.767, 0.767, 0.767,
+        0.767,
+        0.767,
+        0.767,
+        0.767,
         # detector_center=0.2
-        1.097, 0.436, 1.097, 0.436,
+        1.097,
+        0.436,
+        1.097,
+        0.436,
         # detector_center=-0.2
-        0.436, 1.097, 0.436, 1.097,
+        0.436,
+        1.097,
+        0.436,
+        1.097,
         # detector_center=0.5
-        0.857, None, 0.857, None,
+        0.857,
+        None,
+        0.857,
+        None,
         # detector_center=-0.5
-        None, 0.857, None, 0.857,
+        None,
+        0.857,
+        None,
+        0.857,
     ],
     (ExtentPlaceholder.FULL, 1.0): [
         # detector_center=0
-        0.682, 0.682, 0.682, 0.682,
+        0.682,
+        0.682,
+        0.682,
+        0.682,
         # detector_center=0.2
-        0.970, 0.391, 0.970, 0.391,
+        0.970,
+        0.391,
+        0.970,
+        0.391,
         # detector_center=-0.2
-        0.391, 0.970, 0.391, 0.970,
+        0.391,
+        0.970,
+        0.391,
+        0.970,
         # detector_center=0.5
-        0.600, None, 0.600, None,
+        0.600,
+        None,
+        0.600,
+        None,
         # detector_center=-0.5
-        None, 0.600, None, 0.600,
+        None,
+        0.600,
+        None,
+        0.600,
     ],
     (ExtentPlaceholder.FULL, 1.7): [
         # detector_center=0
-        0.893, 0.893, 0.893, 0.893,
+        0.893,
+        0.893,
+        0.893,
+        0.893,
         # detector_center=0.2
-        1.200, 0.522, 1.200, 0.522,
+        1.200,
+        0.522,
+        1.200,
+        0.522,
         # detector_center=-0.2
-        0.522, 1.200, 0.522, 1.200,
+        0.522,
+        1.200,
+        0.522,
+        1.200,
         # detector_center=0.5
-        0.600, None, 0.600, None,
+        0.600,
+        None,
+        0.600,
+        None,
         # detector_center=-0.5
-        None, 0.600, None, 0.600,
+        None,
+        0.600,
+        None,
+        0.600,
     ],
 }
 
@@ -303,9 +477,7 @@ def test_image_extent_placeholder(
                     size=(Nx, Ny), center=image_center, extent=placeholder
                 ),
                 angles=Na,
-                detectors=Detectors(
-                    number=Ns, center=detector_center, extent=2.0
-                ),
+                detectors=Detectors(number=Ns, center=detector_center, extent=2.0),
             )
     else:
         radon = Radon(
@@ -313,9 +485,7 @@ def test_image_extent_placeholder(
                 size=(Nx, Ny), center=image_center, extent=placeholder
             ),
             angles=Na,
-            detectors=Detectors(
-                number=Ns, center=detector_center, extent=2.0
-            ),
+            detectors=Detectors(number=Ns, center=detector_center, extent=2.0),
         )
         assert isinstance(radon.image_domain.extent, float)
         assert radon.image_domain.extent == pytest.approx(expected, abs=0.02), (

--- a/tests/test_fanbeam.py
+++ b/tests/test_fanbeam.py
@@ -24,11 +24,6 @@ if plot_parameter.lower() not in ["0", "false"]:
 else:
     PLOT = False
 
-CL_DOUBLE_SUPPORTED = any(
-    device.double_fp_config
-    for platform in cl.get_platforms()
-    for device in platform.get_devices()
-)
 
 # Names of relevant test-data
 TESTWALNUT = Path(__file__).parent / "walnut.png"
@@ -38,6 +33,14 @@ TESTWALNUTSINOGRAM = Path(__file__).parent / "walnut_sinogram.png"
 ctx = None
 queue = None
 INTERACTIVE = False
+
+# Ensures that no double precision calculations are required 
+# if the used device does not support CL double precision
+ctx_default = cl.create_some_context(interactive=INTERACTIVE)
+CL_DOUBLE_SUPPORTED = all(
+    device.double_fp_config
+    for device in ctx_default.devices
+)
 
 
 def test_projection():
@@ -1394,7 +1397,7 @@ def test_nonquadratic():
 
     # create phantom and cut one side out
     N = 1200
-    img_gpu = create_phantoms(queue, N, dtype=np.float32)
+    img_gpu = create_phantoms(queue, N, dtype=np.dtype("float32"))
     N1 = img_gpu.shape[0]
     N2 = int(img_gpu.shape[0] * 2 / 3.0)
     img_gpu = cl.array.to_device(queue, img_gpu.get()[:, 0:N2, :].copy())

--- a/tests/test_fanbeam.py
+++ b/tests/test_fanbeam.py
@@ -34,13 +34,10 @@ ctx = None
 queue = None
 INTERACTIVE = False
 
-# Ensures that no double precision calculations are required 
+# Ensures that no double precision calculations are required
 # if the used device does not support CL double precision
 ctx_default = cl.create_some_context(interactive=INTERACTIVE)
-CL_DOUBLE_SUPPORTED = all(
-    device.double_fp_config
-    for device in ctx_default.devices
-)
+CL_DOUBLE_SUPPORTED = all(device.double_fp_config for device in ctx_default.devices)
 
 
 def test_projection():

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -173,19 +173,21 @@ def test_composite_operator_forwards_queue():
     assert result.shape == (Nx, Nx)
 
 
-def test_radon_placeholder_rejected_for_detector_extent():
-    with pytest.raises(NotImplementedError, match="Extent placeholders"):
-        Radon(
-            image_domain=ImageDomain(size=16, extent=2.0),
-            angles=10,
-            detectors=Detectors(number=20, extent=ExtentPlaceholder.FULL),
-        )
+def test_radon_placeholder_resolved_for_detector_extent():
+    radon = Radon(
+        image_domain=ImageDomain(size=16, extent=2.0),
+        angles=10,
+        detectors=Detectors(number=20, extent=ExtentPlaceholder.FULL),
+    )
+    assert isinstance(radon.detectors.extent, float)
+    assert radon.detectors.extent > 0.0
 
 
-def test_radon_placeholder_rejected_for_image_extent():
-    with pytest.raises(NotImplementedError, match="Extent placeholders"):
-        Radon(
-            image_domain=ImageDomain(size=16, extent=ExtentPlaceholder.FULL),
-            angles=10,
-            detectors=Detectors(number=20, extent=2.0),
-        )
+def test_radon_placeholder_resolved_for_image_extent():
+    radon = Radon(
+        image_domain=ImageDomain(size=16, extent=ExtentPlaceholder.FULL),
+        angles=10,
+        detectors=Detectors(number=20, extent=2.0),
+    )
+    assert isinstance(radon.image_domain.extent, float)
+    assert radon.image_domain.extent > 0.0

--- a/tests/test_radon.py
+++ b/tests/test_radon.py
@@ -20,17 +20,19 @@ if plot_parameter.lower() not in ["0", "false"]:
 else:
     PLOT = False
 
-CL_DOUBLE_SUPPORTED = any(
-    device.double_fp_config
-    for platform in cl.get_platforms()
-    for device in platform.get_devices()
-)
 
 # Dummy Context
 ctx = None
 queue = None
+INTERACTIVE = False
 
-
+# Ensures that no double precision calculations are required 
+# if the used device does not support CL double precision
+ctx_default = cl.create_some_context(interactive=INTERACTIVE)
+CL_DOUBLE_SUPPORTED = all(
+    device.double_fp_config
+    for device in ctx_default.devices
+)
 def test_projection():
     """
     Basic projection test. Simply computes forward and backprojection
@@ -42,7 +44,7 @@ def test_projection():
     print("Projection test")
 
     # create PyopenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # create test image
@@ -170,7 +172,7 @@ def test_types_contiguity(dtype):
     print("Types and contiguity test")
 
     # create PyopenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # create test image
@@ -278,7 +280,7 @@ def test_weighting():
     print("Weighting test")
 
     # create PyopenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # types of data
@@ -346,7 +348,7 @@ def test_adjointness():
     print("Adjointness test")
 
     # create PyOpenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # types of data_type
@@ -434,7 +436,7 @@ def test_limited_angles():
     """
 
     # create PyOpenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # create test image
@@ -627,7 +629,7 @@ def test_nonquadratic():
     operator for non-quadratic images."""
 
     # create PyOpenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # create phantom but cut of one side
@@ -720,7 +722,7 @@ def test_create_sparse_matrix(dtype):
     backprojection via matrix multiplication.
     """
     # create PyOpenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # Set types of data
@@ -803,7 +805,7 @@ def test_midpoint_shift():
     """
 
     # create PyOpenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # create phantom for test
@@ -892,7 +894,7 @@ def test_angle_input_variants():
     to set the **angle_weights** manually.
     """
     # create PyopenCL context
-    ctx = cl.create_some_context(interactive=False)
+    ctx = cl.create_some_context(interactive=INTERACTIVE)
     queue = cl.CommandQueue(ctx)
 
     # create test image

--- a/tests/test_radon.py
+++ b/tests/test_radon.py
@@ -26,13 +26,12 @@ ctx = None
 queue = None
 INTERACTIVE = False
 
-# Ensures that no double precision calculations are required 
+# Ensures that no double precision calculations are required
 # if the used device does not support CL double precision
 ctx_default = cl.create_some_context(interactive=INTERACTIVE)
-CL_DOUBLE_SUPPORTED = all(
-    device.double_fp_config
-    for device in ctx_default.devices
-)
+CL_DOUBLE_SUPPORTED = all(device.double_fp_config for device in ctx_default.devices)
+
+
 def test_projection():
     """
     Basic projection test. Simply computes forward and backprojection


### PR DESCRIPTION
There is an issue in the tests if the default device does not support double precision, but there is an device which does (as the code checks only if there exists a double-compatible device, but not whether this is the device used for the tests)